### PR TITLE
Test_ChatUseCasesTests_LemengDai

### DIFF
--- a/CSC-207-Group-Project.iml
+++ b/CSC-207-Group-Project.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/out" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/commands/ChatCommand.java
+++ b/src/commands/ChatCommand.java
@@ -72,18 +72,6 @@ public class ChatCommand {
                 break;
             }
 
-
-            // use "/chat-showid-receiver's id-sent time(yyyy.MM.dd hh:mm:ss)" to find the id of a message
-            case "showid": {
-                int chatid = chatManager.getIdByUserAndTime(userid, Integer.parseInt(inputLines[2]), inputLines[3]);
-                if (chatid != 0) {
-                    System.out.println("chat id is " + chatid);
-                } else {
-                    System.out.println("chat does not exist");
-                }
-                break;
-            }
-
             default: System.out.println("unknown command");
         }
     }

--- a/src/entity/inputboundary/Context.java
+++ b/src/entity/inputboundary/Context.java
@@ -7,7 +7,7 @@ import entity.Post;
 /**
  * <p>Context is an abstract class that is inherited by {@link Chat Chat}, {@link Comment Comment}
  * and {@link Post Post}. Context also implements {@link Timeable Timeable}, {@link Searchable Searchable},
- * {@link Postable Postable}</p>}
+ * {@link Postable Postable}, {@link Modelizable Modelizable}</p>}
  * @Author: LemengDai
  */
 public abstract class Context implements Timeable, Searchable, Postable, Modelizable{

--- a/src/presenter/CommentPresenter.java
+++ b/src/presenter/CommentPresenter.java
@@ -14,6 +14,7 @@ import java.util.Map;
  * <p>CommentPresenter is responsible for getting a list of {@link Comment Comment} with username
  * who posts these comments corresponding to a post and then transform them into a single {@link StringBuilder String}
  * which can be displayed later in {@link ShowCommentScreen} ShowCommentScreen.</p>
+ * @Author: LemengDai
  */
 public class CommentPresenter {
 

--- a/src/useCases/ChatUseCases.java
+++ b/src/useCases/ChatUseCases.java
@@ -68,33 +68,12 @@ public class ChatUseCases {
 
     }
 
-    /**
-     * <p>returns the id of the chat with inputted sender's id, receiver's id and time sent</p>
-     *
-     * @param sender the id of the user that sent the chat
-     * @param receiver the id of the user that received the chat
-     * @param timestamp the time that the chat is sent
-     * @return the id of the chat
-     */
-    public int getIdByUserAndTime(int sender, int receiver, String timestamp){
-        for (int id: chats.keySet()){
-            if (chats.get(id).getSender_id() == sender && chats.get(id).getReceiver_id() == receiver &&
-                    chats.get(id).getTime().equals(timestamp)){
-                return id;
-            }
-        }
-        return 0;
-    }
     public Map<Integer, ChatResponseModel> getChats() {
         Map<Integer, ChatResponseModel> chatResponseModelMap = new HashMap<>();
         for (Chat chat : chats.values()) {
             chatResponseModelMap.put(chat.getId(), chat.responseModel());
         }
         return chatResponseModelMap;
-    }
-
-    public Map<Integer, Chat> getChatList(){
-        return chats;
     }
 
 }

--- a/test/UseCases/ChatUseCasesTests.java
+++ b/test/UseCases/ChatUseCasesTests.java
@@ -10,7 +10,8 @@ import java.util.Map;
 
 /**
  * <p>ChatUseCasesTest is a test class for ChatUseCases.</p>
- * @Author: LemengDai
+ * @Author: Jiahao Gu
+ * @Modifiedby: LemengDai
  */
 public class ChatUseCasesTests extends TestCase {
 

--- a/test/UseCases/ChatUseCasesTests.java
+++ b/test/UseCases/ChatUseCasesTests.java
@@ -1,62 +1,53 @@
 package UseCases;
 
-
-import model.request.ChatRequestModel;
-import org.junit.After;
-import org.junit.BeforeClass;
+import junit.framework.TestCase;
+import model.response.ChatResponseModel;
 import org.junit.Test;
 import useCases.ChatUseCases;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-
-/*
- * Author: Jiahao Gu
+/**
+ * <p>ChatUseCasesTest is a test class for ChatUseCases.</p>
+ * @Author: LemengDai
  */
+public class ChatUseCasesTests extends TestCase {
 
-public class ChatUseCasesTests {
-    static ChatUseCases actual;
-
-    @BeforeClass
-
-    public static void setUp() {
-        ChatRequestModel chat1 = new ChatRequestModel(1, 1, 2, "Hello!", "2021");
-        ChatRequestModel chat2 = new ChatRequestModel(2, 2, 1, "How are u?", "2022");
-        ChatRequestModel chat3 = new ChatRequestModel(3, 1, 2, "Good!", "2022");
-        Map<Integer, ChatRequestModel> cuc = new HashMap<>();
-        cuc.put(1, chat1);
-        cuc.put(2, chat2);
-        cuc.put(3, chat3);
-        actual = new ChatUseCases(cuc);
+    public void setUp() throws Exception {
+        super.setUp();
     }
 
-    @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
     }
 
     @Test(timeout = 500)
-    public void testAddChat(){
-        actual.addChat(2, 1,  "me2!");
-        int senderid = actual.getChatList().get(4).getSender_id();
-        int receiverid = actual.getChatList().get(4).getReceiver_id();
-        String content = actual.getChatList().get(4).getContent();
+    public void testAddChat() {
+        ChatUseCases manager = new ChatUseCases(new HashMap<>());
+        manager.addChat(1, 2, "Hello" );
+        ChatResponseModel chat = manager.getChats().get(1);
+        String actual = "Hello";
+        String expected = (String) chat.get().get(3);
+        assertEquals("There is error in ChatManager.addChat!", actual, expected);
 
-        assertEquals("There is error in addChat!", 2, senderid);
-        assertEquals("There is error in addChat!", 1, receiverid);
-        assertEquals("There is error in addChat!", "me2!", content);
     }
-
     @Test(timeout = 500)
-    public void testDeleteChat(){
-        actual.deleteChat(4);
-        assertEquals("There is error in deleteChat!",3, actual.getChatList().size());
+    public void testDeleteChat() {
+        ChatUseCases manager = new ChatUseCases(new HashMap<>());
+        manager.addChat(1, 2, "Hello" );
+        manager.addChat(1, 2, "I'm Alice" );
+        manager.deleteChat(1);
+        ChatResponseModel actual = manager.getChats().get(1);
+        assertNull("There is error in ChatManager.deleteChat!", actual);
     }
-
     @Test(timeout = 500)
-    public void testGetIdByUserAndTime(){
-        assertEquals("There is error in getIdByUserAndTime!",1,
-                actual.getIdByUserAndTime(1,2, "2021"));
+    public void testGetChats() {
+        ChatUseCases manager = new ChatUseCases(new HashMap<>());
+        manager.addChat(1, 2, "Hello");
+        manager.addChat(1, 2, "I'm Alice");
+        Map<Integer, ChatResponseModel> chatResponseModelMap = manager.getChats();
+        String actual = (String) chatResponseModelMap.get(2).get().get(3);
+        String expected = "I'm Alice";
+        assertEquals("There is error in ChatManager.getChats!", actual, expected);
     }
 }


### PR DESCRIPTION
Deleted getIdByUserAndTime in ChatUseCases because it is rarely used and then deleted its usages. Also deleted getChatList in ChatUseCases because we are not allowed to directly return Chat entity and we have to use ChatResponseModel. Modified ChatUseCasesTests.